### PR TITLE
Enhance RTL Support for Persian Text and Numbered Lists in Notion

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,8 @@
 .rtl-text ol,
 .rtl-text li,
 .rtl-text .notion-toggle,
-.rtl-text .notion-toggle-content {
+.rtl-text .notion-toggle-content,
+.rtl-text .pseudoBefore {
   direction: rtl;
   text-align: right;
 }


### PR DESCRIPTION
This Pull Request improves the RTL (Right-to-Left) support for Persian content in Notion by addressing the following changes:

1. Refactored the `applyRtlToPersianText()` function to handle both editable text elements and numbered list blocks.
2. Added logic to detect and adjust the `.pseudoBefore` element in numbered lists to ensure proper alignment with Persian text.
3. Ensured non-Persian content remains in its default LTR configuration to avoid disrupting the Notion's behavior.
4. Updated the CSS to apply proper styling for numbered lists, including their numbers, to align with the text direction.

These changes aim to provide a seamless experience for RTL users in Notion by ensuring that both text and list numbering are properly aligned in RTL direction when necessary.
