### PR TITLE
Enhance RTL Support for Persian Text and Numbered Lists in Notion

### DIFF
--- a/content.js
+++ b/content.js
@@ -22,6 +22,24 @@ function applyRtlToPersianText() {
       element.classList.remove('rtl-text');
     }
   });
+  
+  // Apply RTL/LTR on numbered list blocks and pseudoBefore element (which shows the list number)
+  const numberedListElements = document.querySelectorAll('.notion-numbered_list-block');
+  numberedListElements.forEach(element => {
+    if (persianRegex.test(element.textContent)) {
+      const pseudoBefore = element.querySelector('.pseudoBefore');
+      if (pseudoBefore) {
+        pseudoBefore.style.direction = 'rtl';
+        pseudoBefore.style.textAlign = 'right';
+      }      
+    } else {
+      const pseudoBefore = element.querySelector('.pseudoBefore');
+      if (pseudoBefore) {
+        pseudoBefore.style.direction = 'ltr';
+        pseudoBefore.style.textAlign = 'left';
+      }
+    }
+  });
 }
 
 // Run the function on page load

--- a/style.css
+++ b/style.css
@@ -14,7 +14,8 @@
 .rtl-text ol,
 .rtl-text li,
 .rtl-text .notion-toggle,
-.rtl-text .notion-toggle-content {
+.rtl-text .notion-toggle-content,
+.rtl-text .pseudoBefore {
   direction: rtl;
   text-align: right;
 }


### PR DESCRIPTION
This Pull Request introduces improvements to the RTL (Right-to-Left) support for Persian content in Notion by addressing the following:

1. Refactored the `applyRtlToPersianText()` function to handle both editable text elements and numbered list blocks seamlessly.
2. Added logic to detect and properly align the `.pseudoBefore` element in numbered lists to ensure numbers align with Persian text direction.
3. Ensured non-Persian content remains unaffected by maintaining its default LTR configuration.
4. Updated CSS styles to better support numbered lists and their alignment with RTL text.

These changes improve the experience for Persian users in Notion by ensuring that both text and list numbering are properly aligned when RTL is needed.