### PR TITLE
Add forced LTR for math elements to fix equation rendering

### DIFF
--- a/content.js
+++ b/content.js
@@ -40,6 +40,14 @@ function applyRtlToPersianText() {
       }
     }
   });
+  // Force math elements to LTR by setting dir="ltr"
+  const mathElements = document.querySelectorAll('.katex, .notion-text-equation-token');
+  mathElements.forEach(elem => {
+    elem.setAttribute('dir', 'ltr');
+    elem.style.direction = 'ltr';
+    elem.style.textAlign = 'left';
+    elem.style.unicodeBidi = 'bidi-override';
+  });
 }
 
 // Run the function on page load


### PR DESCRIPTION
- Introduced `dir="ltr"` attribute and explicit style overrides (`direction: ltr`, `textAlign: left`, `unicodeBidi: bidi-override`) for `.katex` and `.notion-text-equation-token` elements.
- Ensures that math expressions remain left-aligned even when the parent block is RTL.
- Retained existing logic for applying RTL to blocks containing Persian text and numbered lists.

# Before:
![image](https://github.com/user-attachments/assets/0f908d56-ed37-4a56-ba53-ac5ce5fbe901)
# Now:
![image](https://github.com/user-attachments/assets/70a65dc1-5144-4389-ba19-43013906de3d)
